### PR TITLE
fix: ensure that the function isn't called early

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_TAG    = 0.0.1
-IMAGE_NAME   = openshiftcloudfunctions/js-runtime
+IMAGE_NAME   = oscf/js-runtime
 DOCKER_IMAGE = docker.io/$(IMAGE_NAME):$(IMAGE_TAG)
 QUAY_IMAGE   = quay.io/$(IMAGE_NAME):$(IMAGE_TAG)
 TEST_IMAGE   = $(IMAGE_NAME):candidate

--- a/src/context.js
+++ b/src/context.js
@@ -1,43 +1,7 @@
-const cldeventsv02 = require('cloudevents-sdk/v02');
-const cldeventsv03 = require('cloudevents-sdk/v03');
-
 class Context {
   constructor(request, response) {
     this.request = request;
     this.response = response;
-
-    // Unmarshall Knative Eventing request to cloudevent
-    if (('ce-type' in request.headers) && request.headers['ce-type'].startsWith('dev.knative')) {
-      var data = "";
-      request.setEncoding('utf8');
-
-      request.on('data', function (chunk) {
-        data += chunk;
-        if (data.length == parseInt(request.headers['content-length'], 10)) {
-          // Event 'end' is not emmited at the end of every request,
-          // we have to do that explicitly
-          request.emit('end');
-        }
-      });
-
-      request.on('end', function () {
-        var unmarshaller = null;
-        if (request.headers['ce-specversion'] == '0.2') {
-          unmarshaller = new cldeventsv02.HTTPUnmarshaller();
-        } else if (request.headers['ce-specversion'] == '0.3') {
-          unmarshaller = new cldeventsv03.HTTPUnmarshaller();
-        }
-        unmarshaller.unmarshall(data, request.headers)
-          .then(cldevent => {
-            this.cloudevent = cldevent;
-          }).catch(err => {
-            console.error(err);
-            this.error = err;
-          });
-      });
-
-    }
-
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 const http = require('http');
 const Context = require('./context.js');
 const protection = require('overload-protection');
+const cldeventsv02 = require('cloudevents-sdk/v02');
+const cldeventsv03 = require('cloudevents-sdk/v03');
 
 // Default LIVENESS/READINESS urls
 const READINESS_URL = '/health';
@@ -25,6 +27,42 @@ const server = http.createServer((req, res) => {
   // Check if health path
   if (req.url === readinessURL || req.url === livenessURL) {
     protect(req, res, () => res.end("OK"))
+  } else if (('ce-type' in req.headers) && req.headers['ce-type'].startsWith('dev.knative')) {
+    let data = '';
+    req.setEncoding('utf8');
+
+    req.on('data', chunk => {
+      data += chunk;
+      if (data.length === parseInt(req.headers['content-length'], 10)) {
+        // Event 'end' is not emmited at the end of every request,
+        // we have to do that explicitly
+        req.emit('end');
+      }
+    });
+
+    req.on('end', _ => {
+      let unmarshaller;
+      const context = new Context(req, res);
+      const version = req.headers['ce-specversion'];
+      if (version === '0.2') {
+        unmarshaller = new cldeventsv02.HTTPUnmarshaller();
+      } else if (version === '0.3') {
+        unmarshaller = new cldeventsv03.HTTPUnmarshaller();
+      } else {
+        console.warn(`Unknown cloud event version detected: ${version}`);
+        return res.end(context);
+      }
+
+      unmarshaller.unmarshall(data, req.headers)
+        .then(cldevent => {
+          context.cloudevent = cldevent;
+        }).catch(err => {
+          console.error(err);
+          context.error = err;
+        }).finally(_ => {
+          res.end(func(context));
+        });
+    });
   } else {
     res.end(func(new Context(req, res)));
   }


### PR DESCRIPTION
Since the incoming cloud event data is being piped in via an
async stream, we can't call the hosted function until the stream
has ended.

Also, use oscf namespace for published image.