### PR TITLE
doc: use oscf/js-runtime in running locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TEST_IMAGE   = $(IMAGE_NAME):candidate
 
 build:
 	docker build -t $(DOCKER_IMAGE) .
+	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(TEST_IMAGE)
 	# docker build -t $(QUAY_IMAGE) .
 
 test:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ to contain the runtime source code. To mount this into a running container
 execute the following command.
 
 ```sh
-docker run --rm --cidfile my-faas-test.cid -a stdout -a stderr -v /path/to/local/source/dir:/home/node/usr -p 8080:8080 redhat-faas/js-runtime &
+docker run --rm -a stdout -a stderr -v /path/to/local/source/dir:/home/node/usr -p 8080:8080 oscf/js-runtime:candidate
+```
+
+To stop the running container:
+```sh
+$ docker ps
+$ docker stop <CONTAINER ID>
 ```
 
 ## Testing


### PR DESCRIPTION
This commit uses the image name built by the make build target, instead
of `redhat-faas/js-runtime`.

It also removes the `cidfile` as this can be confusing to new users as
unless the manually delete this file there will be an error the next
time it is run:
```console
docker: Container ID file found, make sure the other container isn't
running or delete my-faas-test.cid.
```