### PR TITLE
src: don't create a new Context instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ const server = http.createServer((req, res) => {
         res.end(err);
       });
   } else {
-    res.end(func(new Context(req, res)));
+    res.end(func(context));
   }
 });
 


### PR DESCRIPTION
This commit removes the creation of a second Context instance when
invoking a non-cloudevent function.