### PR TITLE
chore: set package-lock creation to false

### DIFF
--- a/src/.npmrc
+++ b/src/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
* This adds a .npmrc file in the src directory with the package-lock set false

I noticed that when the image is first built,  a package-lock.json is created in the `src`, which probably isn't something you want,  since it is in the .gitignore file anyway.

 