### PR TITLE
src: add home_dir argument and use HOME env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,18 @@ FROM node:12-alpine
 
 EXPOSE 8080
 
-COPY src /home/node/src
+ARG home_dir="/home/node"
+
+COPY src ${home_dir}/src
 COPY s2i /usr/libexec/s2i
 
-RUN mkdir -p /home/node/usr && \
-  chmod -R 777 /home/node && \
-  cd /home/node/src && \
+RUN mkdir -p ${home_dir}/usr && \
+  chmod -R 777 ${home_dir} && \
+  cd ${home_dir}/src && \
   npm install
 
-ENV HOME /home/node
+ENV HOME $home_dir
 
 USER 1001
 
-CMD ["/home/node/src/run.sh"]
+CMD ${HOME}/src/run.sh

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -x
 
-# Copy user source to /home/node/usr
-cp -Rfpv /tmp/src/* /home/node/usr
+# Copy user source to ${HOME}/usr
+cp -Rfpv /tmp/src/* ${HOME}/usr
 
 # Install user dependencies if they exist
-cd /home/node/usr
+cd ${HOME}/usr
 if [ -f package.json ] ; then
   npm install --only=prod
 fi

--- a/s2i/run
+++ b/s2i/run
@@ -2,8 +2,8 @@
 set -x
 
 # Uncomment for debugging
-# ls -l /home/node/usr /home/node/usr/node_modules /home/node/usr/node_modules/is-number /home/node/src /home/node/src/node_modules /home/node/src/node_modules/is-number
+# ls -l ${HOME}/usr ${HOME}/usr/node_modules ${HOME}/usr/node_modules/is-number ${HOME}/src ${HOME}/src/node_modules ${HOME}/src/node_modules/is-number
 
-cd /home/node/src
+cd ${HOME}/src
 
-NODE_PATH=/home/node/usr:/home/node/src node .
+NODE_PATH=${HOME}/usr:${HOME}/src node .

--- a/src/run.sh
+++ b/src/run.sh
@@ -3,7 +3,7 @@ set -x
 
 umask 000
 
-cd /home/node/usr
+cd ${HOME}/usr
 
 if [ -f package.json ] ; then
   export NO_UPDATE_NOTIFIER=true


### PR DESCRIPTION
This commit updates the Dockerfile and adds an argument named `home_dir`
which is used in docker build commands. This is also the value used to
set the `HOME` environment variable and updates have also been made to
various scripts to use this environment variable instead of hard coded
/home/node paths.