### PR TITLE
fix: close on SIGTERM and SIGINT signals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,20 @@ const userFunction = require(path.join(`${__dirname},`, '..', 'usr'));
 framework(userFunction, 8080, server => {
   console.log('FaaS framework initialized');
 });
+
+process.stdin.resume();
+
+let confirm = false;
+process.on('SIGINT', signal => {
+  if (confirm) {
+    process.exit(130);
+  } else {
+    console.log('Press Control+C again to confirm.');
+    confirm = true;
+  }
+});
+
+process.on('SIGTERM', signal => {
+  console.log(`Received ${signal}`);
+  process.exit(143);
+});

--- a/src/run.sh
+++ b/src/run.sh
@@ -12,4 +12,4 @@ fi
 
 cd ../src
 
-node .
+exec node .


### PR DESCRIPTION
Related to #27 

When sending a SIGTERM to the running container nothing happens:

![2020-04-17_15-11](https://user-images.githubusercontent.com/6443576/79600948-697a8480-80be-11ea-923e-6da8e9f66557.png)

This fix handles SIGTERM and SIGINT:

![2020-04-17_15-12](https://user-images.githubusercontent.com/6443576/79601131-b0687a00-80be-11ea-8e80-a610784befdc.png)

![2020-04-17_15-13](https://user-images.githubusercontent.com/6443576/79601134-b3fc0100-80be-11ea-814b-38f66b9d51cb.png)
